### PR TITLE
Remove kubernetes client dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,13 +93,6 @@
       <artifactId>log4j-core</artifactId>
       <version>2.8.1</version>
     </dependency>
-
-    <dependency>
-      <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-client</artifactId>
-      <version>1.4.34</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>


### PR DESCRIPTION
`vertx-config-kubernetes-configmap` requires dependency for `kubernetes-client` and `test` scope introduces runtime failures 

> java.lang.NoClassDefFoundError: io/fabric8/kubernetes/client/KubernetesClientException
	at io.vertx.config.kubernetes.ConfigMapStoreFactory.create(ConfigMapStoreFactory.java:19)
	at io.vertx.config.impl.ConfigRetrieverImpl.<init>(ConfigRetrieverImpl.java:71)
	at io.vertx.config.ConfigRetriever.create(ConfigRetriever.java:32)
	at io.openshift.booster.HttpApplication.setUpConfiguration(HttpApplication.java:122)
	at io.openshift.booster.HttpApplication.start(HttpApplication.java:51)
	at io.vertx.core.AbstractVerticle.start(AbstractVerticle.java:111)
	at io.vertx.core.impl.DeploymentManager.lambda$doDeploy$8(DeploymentManager.java:434)
	at io.vertx.core.impl.ContextImpl.lambda$wrapTask$2(ContextImpl.java:337)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:403)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:445)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.ClassNotFoundException: io.fabric8.kubernetes.client.KubernetesClientException
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
... 13 more