### PR TITLE
fix: add default configmap on deployment

### DIFF
--- a/src/main/fabric8/configmap.yml
+++ b/src/main/fabric8/configmap.yml
@@ -1,0 +1,9 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  creationTimestamp: 2016-02-18T19:14:38Z
+  name: app-config
+data:
+  app-config: |
+    message : "Hello, %s from a ConfigMap !"
+    level : INFO

--- a/src/main/fabric8/deployment.yaml
+++ b/src/main/fabric8/deployment.yaml
@@ -8,7 +8,7 @@ spec:
             name: app-config
             # Define the items from the config map to mount
             items:
-            - key: app-config.yml
+            - key: app-config
               path: app-config.yml
             # Volume name (used as reference below)
           name: config


### PR DESCRIPTION
Adding a default will make this booster work on openshift.io