### PR TITLE
unify the test ConfigMap with the main ConfigMap used in S2I flow

### DIFF
--- a/src/test/java/io/openshift/booster/OpenShiftIT.java
+++ b/src/test/java/io/openshift/booster/OpenShiftIT.java
@@ -51,8 +51,8 @@ public class OpenShiftIT {
 
     @Test
     public void testBThatWeServeAsExpected() {
-        get("/api/greeting").then().body("content", equalTo("Hello, World from a ConfigMap !"));
-        get("/api/greeting?name=vert.x").then().body("content", equalTo("Hello, vert.x from a ConfigMap !"));
+        get("/api/greeting").then().body("content", equalTo("Hello World from a ConfigMap!"));
+        get("/api/greeting?name=vert.x").then().body("content", equalTo("Hello vert.x from a ConfigMap!"));
     }
 
     @Test

--- a/src/test/resources/test-config.yml
+++ b/src/test/resources/test-config.yml
@@ -4,5 +4,5 @@ metadata:
   name: app-config
 data:
   app-config.yml: |-
-      message : "Hello, %s from a ConfigMap !"
+      message : "Hello %s from a ConfigMap!"
       level : INFO


### PR DESCRIPTION
This is to reduce the difference between FMP and S2I flow tests.